### PR TITLE
fix(runtime): unlink junction instead of rmSync on windows

### DIFF
--- a/server/src/engine/dsh_runtime/trusted_client_plugins.js
+++ b/server/src/engine/dsh_runtime/trusted_client_plugins.js
@@ -5,8 +5,8 @@ import {
   readFileSync,
   readlinkSync,
   realpathSync,
-  rmSync,
   symlinkSync,
+  unlinkSync,
 } from "node:fs";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -92,7 +92,7 @@ function ensureLink(link, target) {
     }
     const current = resolve(dirname(link), readlinkSync(link));
     if (current === target) return;
-    rmSync(link);
+    unlinkSync(link);
   }
   symlinkSync(target, link, "junction");
 }
@@ -105,7 +105,7 @@ function removeRetiredLinks(dshHome) {
     if (!stat.isSymbolicLink()) {
       throw new Error(`退役 DSH plugin 解析位被普通文件占用：${link}`);
     }
-    rmSync(link);
+    unlinkSync(link);
   }
 }
 


### PR DESCRIPTION
Fixes #10

## 变更内容

Windows 上重建 Profile 链接时，将 `rmSync(link)` 改为 `unlinkSync(link)`（共两处：重建受信任插件链接、清理退役插件链接），与 DSH 上游 `dsh-app-boot` 的 `ensureSymlink` 行为保持一致：

- Windows 的 junction 是重解析点，`rmSync` 会按目录处理并抛 `EISDIR`（"Path is a directory"），导致 DSH 运行时启动失败、应用提示"本地服务没有正常启动"；
- `unlinkSync` 只删除链接本身，不触碰链接目标。

## 复现步骤

1. 在 Windows 安装桌面版并启动一次（会在用户数据目录的 Profile 模块目录下创建指向安装目录的链接）。
2. 卸载应用或把安装目录移动到其他路径。
3. 重新安装/启动 → 弹出"本地服务没有正常启动"，日志报 `Path is a directory: ...\@deepseek-ai\dsh-product-bridge`。

## 验证情况

- 本机（Windows）按上述步骤复现；手动删除残留 junction 后，应用越过该错误继续启动。
- 另有一个独立的兼容性问题（#11，DSH rc.6 与 rc.2 共享用户数据目录时的凭据格式差异），不属于本 PR 范围。
